### PR TITLE
Allow decompressing SLLZ while reading Par and converting to ParFile without compression

### DIFF
--- a/src/TF3.Tests.Yakuza/ParTests.cs
+++ b/src/TF3.Tests.Yakuza/ParTests.cs
@@ -616,6 +616,40 @@ namespace TF3.Tests.Yakuza
         }
 
         [Test]
+        public void ReadParWithDecompression()
+        {
+            byte[] data = new byte[_data.Length];
+
+            Array.Copy(_data, data, _data.Length);
+
+            using DataStream ds = DataStreamFactory.FromArray(data, 0, data.Length);
+            BinaryFormat binary = new BinaryFormat(ds);
+
+            var converter = new Reader();
+            var parameters = new ReaderParameters
+            {
+                DecompressFiles = true,
+            };
+
+            converter.Initialize(parameters);
+            NodeContainerFormat result = converter.Convert(binary);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(".", result.Root.Name);
+            Assert.IsTrue(result.Root.IsContainer);
+            Assert.AreEqual(2, result.Root.Children.Count);
+            Assert.AreEqual("dir1", result.Root.Children[0].Name);
+            Assert.IsTrue(result.Root.Children[0].IsContainer);
+
+            Node n = Navigator.SearchNode(result.Root, "/./dir1/test1.txt");
+            ParFile file = n.GetFormatAs<ParFile>();
+
+            Assert.IsNotNull(file);
+            Assert.IsFalse(file.FileInfo.IsCompressed());
+            Assert.AreEqual(file.FileInfo.CompressedSize, file.FileInfo.OriginalSize);
+        }
+
+        [Test]
         public void ReadParLittleEndian()
         {
             byte[] data = new byte[_dataLittleEndian.Length];

--- a/src/TF3.Tests.Yakuza/SllzTests.cs
+++ b/src/TF3.Tests.Yakuza/SllzTests.cs
@@ -192,6 +192,29 @@ namespace TF3.Tests.Yakuza
         }
 
         [Test]
+        public void CompressNone()
+        {
+            byte[] data = new byte[_plain.Length];
+
+            Array.Copy(_plain, data, _plain.Length);
+
+            using DataStream expected = DataStreamFactory.FromArray(data, 0, data.Length);
+            using DataStream ds = DataStreamFactory.FromArray(data, 0, data.Length);
+            BinaryFormat binary = new BinaryFormat(ds);
+
+            var converter = new Compress();
+            var parameters = new CompressorParameters
+            {
+                CompressionType = CompressionType.None,
+            };
+            converter.Initialize(parameters);
+
+            YarhlPlugin.YakuzaCommon.Formats.ParFile compressed = converter.Convert(binary);
+            Assert.AreEqual(data.Length, compressed.Stream.Length);
+            Assert.IsTrue(expected.Compare(compressed.Stream));
+        }
+
+        [Test]
         public void CompressStandard()
         {
             byte[] data = new byte[_plain.Length];

--- a/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Par/ReaderParameters.cs
+++ b/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Par/ReaderParameters.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace TF3.YarhlPlugin.YakuzaCommon.Converters.Par
+{
+    using TF3.YarhlPlugin.YakuzaCommon.Enums;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// Parameters for PAR reader.
+    /// </summary>
+    public class ReaderParameters
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReaderParameters"/> class.
+        /// </summary>
+        public ReaderParameters()
+        {
+            DecompressFiles = false;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether files will be automatically decompressed.
+        /// </summary>
+        public bool DecompressFiles { get; set; }
+    }
+}

--- a/src/TF3.YarhlPlugin.YakuzaCommon/Converters/ParFile/FromBinaryFormat.cs
+++ b/src/TF3.YarhlPlugin.YakuzaCommon/Converters/ParFile/FromBinaryFormat.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace TF3.YarhlPlugin.YakuzaCommon.Converters.ParFile
+{
+    using System;
+    using TF3.YarhlPlugin.YakuzaCommon.Enums;
+    using TF3.YarhlPlugin.YakuzaCommon.Formats;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// Creates a ParFile from BinaryFormat.
+    /// </summary>
+    public class FromBinaryFormat : IConverter<BinaryFormat, ParFile>
+    {
+        /// <summary>
+        /// Create a ParFile from BinaryFormat.
+        /// </summary>
+        /// <param name="source">original format.</param>
+        /// <returns>The converted ParFile.</returns>
+        public ParFile Convert(BinaryFormat source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return new ParFile(source.Stream);
+        }
+    }
+}

--- a/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Sllz/Compress.cs
+++ b/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Sllz/Compress.cs
@@ -52,6 +52,7 @@ namespace TF3.YarhlPlugin.YakuzaCommon.Converters.Sllz
 
             return _compressorParameters.CompressionType switch
             {
+                CompressionType.None => (ParFile)ConvertFormat.With<Converters.ParFile.FromBinaryFormat>(source),
                 CompressionType.Standard => (ParFile)ConvertFormat.With<CompressStandard, CompressorParameters>(_compressorParameters, source),
                 CompressionType.Zlib => (ParFile)ConvertFormat.With<CompressZlib, CompressorParameters>(_compressorParameters, source),
                 _ => throw new FormatException($"SLLZ: Bad Compression Type ({_compressorParameters.CompressionType})")

--- a/src/TF3.YarhlPlugin.YakuzaCommon/Enums/CompressionType.cs
+++ b/src/TF3.YarhlPlugin.YakuzaCommon/Enums/CompressionType.cs
@@ -25,6 +25,11 @@ namespace TF3.YarhlPlugin.YakuzaCommon.Enums
     public enum CompressionType
     {
         /// <summary>
+        /// No compression.
+        /// </summary>
+        None = 0x00,
+
+        /// <summary>
         /// Standard compression (LZ variant)
         /// </summary>
         Standard = 0x01,

--- a/src/TF3.YarhlPlugin.YakuzaCommon/Types/ParFileInfo.cs
+++ b/src/TF3.YarhlPlugin.YakuzaCommon/Types/ParFileInfo.cs
@@ -97,6 +97,6 @@ namespace TF3.YarhlPlugin.YakuzaCommon.Types
         /// Check if file is compressed.
         /// </summary>
         /// <returns>True if the file is compressed.</returns>
-        public bool IsCompressed() => (Flags & 0x80000000) == 0x8000000;
+        public bool IsCompressed() => (Flags & 0x80000000) == 0x80000000;
     }
 }

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="SceneGate-Preview" value="https://pkgs.dev.azure.com/SceneGate/SceneGate/_packaging/SceneGate-Preview/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="SceneGate-Preview">
+      <package pattern="Yarhl*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
### Description

A `ReaderParameters` class was added for `Converters.Par.Reader` with an option to `DecompressFiles` automatically while reading the par.

A converter from `ParFile` to `BinaryFormat` was added to avoid the need to use `Converters.Sllz.Compress` as a writer when rebuilding assets.

### Example
These examples apply to game scripts.

Instead of having to add `TF3.YarhlPlugin.YakuzaCommon.Converters.Sllz.Decompress` as a reader for every file contained inside a par (if the file is compressed), a parameter can be added to the script and used with `Converters.Par.Reader` in the "ParameterId" field to decompress all ParFiles that have compression.

Instead of having to compress all files that are contained inside pars, the `TF3.YarhlPlugin.YakuzaCommon.Converters.ParFile.FromBinaryFormat` converter can be added as a writer to convert a `BinaryFormat` to `ParFile` without compressing.

This closes #10
