### PR TITLE
Add Par WriterParameters option to use ToUpperInvariant when sorting nodes

### DIFF
--- a/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Par/Writer.cs
+++ b/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Par/Writer.cs
@@ -60,7 +60,7 @@ namespace TF3.YarhlPlugin.YakuzaCommon.Converters.Par
 
             // Reorder nodes
             source.Root.SortChildren((x, y) =>
-                string.CompareOrdinal(x.Name.ToLowerInvariant(), y.Name.ToLowerInvariant()));
+                string.CompareOrdinal(x.Name.ToUpperInvariant(), y.Name.ToUpperInvariant()));
 
             // Fill node indexes
             FillNodeIndexes(source.Root);

--- a/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Par/Writer.cs
+++ b/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Par/Writer.cs
@@ -59,8 +59,16 @@ namespace TF3.YarhlPlugin.YakuzaCommon.Converters.Par
             }
 
             // Reorder nodes
-            source.Root.SortChildren((x, y) =>
-                string.CompareOrdinal(x.Name.ToUpperInvariant(), y.Name.ToUpperInvariant()));
+            if (_writerParameters.SortWithUpperInvariant)
+            {
+                source.Root.SortChildren((x, y) =>
+                    string.CompareOrdinal(x.Name.ToUpperInvariant(), y.Name.ToUpperInvariant()));
+            }
+            else
+            {
+                source.Root.SortChildren((x, y) =>
+                    string.CompareOrdinal(x.Name.ToLowerInvariant(), y.Name.ToLowerInvariant()));
+            }
 
             // Fill node indexes
             FillNodeIndexes(source.Root);

--- a/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Par/WriterParameters.cs
+++ b/src/TF3.YarhlPlugin.YakuzaCommon/Converters/Par/WriterParameters.cs
@@ -37,6 +37,7 @@ namespace TF3.YarhlPlugin.YakuzaCommon.Converters.Par
             Version = 0x00020001;
             WriteDataSize = false;
             DotRoot = true;
+            SortWithUpperInvariant = false;
             OutputStream = null;
         }
 
@@ -64,6 +65,12 @@ namespace TF3.YarhlPlugin.YakuzaCommon.Converters.Par
         /// Gets or sets a value indicating whether the root name is a dot or a full name.
         /// </summary>
         public bool DotRoot { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use ToUpperInvariant or ToLowerInvariant (default) when sorting node names.
+        /// </summary>
+        /// <remarks>Kenzan relies on the file order and some files will not be loaded without this option enabled.</remarks>
+        public bool SortWithUpperInvariant { get; set; }
 
         /// <summary>
         /// Gets or sets the DataStream to write the file.


### PR DESCRIPTION
### Description

Adds a `WriterParameters` option, `SortWithUpperInvariant`, that changes the sorting order of nodes. For whatever reason, Kenzan relies on file order and will fail to load files with the incorrect order.

What made me notice this is that the underscore (`_`) seemed to have a higher ordinal than lower case characters in the original par (`pausepar/pause.par`).

Example:
`2d_cf_jinbutsu_denshichirou.dds` is listed before
`2d_cf_jin_denshichirou.dds`

which implies `_` (0x5F) has a higher ordinal than `b` (0x62), which is not true.

This has been added as an option, because other games do not seem to follow this specific sorting (Yakuza 0 for example).

Feel free to make suggestions/improvements if the current implementation is not sufficient.
